### PR TITLE
Create trip mutation

### DIFF
--- a/app/graphql/mutations/trips/create_trip.rb
+++ b/app/graphql/mutations/trips/create_trip.rb
@@ -1,0 +1,15 @@
+module Mutations
+  module Trips
+    class CreateTrip < Mutations::BaseMutation
+      argument :user_id, ID, required: true
+      argument :name, String, required: false
+      argument :traveled_to, Boolean, required: false
+
+      type Types::TripType
+
+      def resolve(attributes)
+        Trip.create!(attributes)
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,10 +1,5 @@
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    field :test_field, String, null: false,
-                               description: 'An example field added by the generator'
-    def test_field
-      'Hello World'
-    end
+    field :create_trip, mutation: Mutations::Trips::CreateTrip, description: 'Create a new trip'
   end
 end

--- a/app/graphql/types/trip_type.rb
+++ b/app/graphql/types/trip_type.rb
@@ -1,0 +1,8 @@
+module Types
+  class TripType < Types::BaseObject
+    field :id, ID, null: false
+    field :user_id, ID, null: false
+    field :name, String, null: true
+    field :traveled_to, Boolean, null: false
+  end
+end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -4,5 +4,4 @@ class Trip < ApplicationRecord
   has_many :photos, through: :photo_trips
 
   validates :name, presence: true
-  validates :traveled_to, presence: true
 end

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -9,6 +9,5 @@ RSpec.describe Trip, type: :model do
   
   describe 'validations' do
     it { should validate_presence_of :name }
-    it { should validate_presence_of :traveled_to }
   end
 end

--- a/spec/requests/graphql/mutations/trips/create_trip_spec.rb
+++ b/spec/requests/graphql/mutations/trips/create_trip_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Mutations::Trips::CreateTrip, type: :request do
+  describe '.resolve' do
+    before :each do
+      @user = create(:user)
+    end
+
+    it 'creates a trip' do
+      attributes = {
+        userId: @user.id,
+        name: 'Caye Caulker, Belize',
+        traveledTo: false
+      }
+
+      post graphql_path, params: { query: query(attributes) }
+      result = JSON.parse(response.body)
+
+      expect(Trip.count).to eq(1)
+      data = result['data']['createTrip']
+      expect(data['userId']).to eq(@user.id.to_s)
+      expect(data['name']).to eq(attributes[:name])
+      expect(data['traveledTo']).to eq(attributes[:traveledTo])
+    end
+
+    def query(attributes)
+      <<~GQL
+        mutation {
+          createTrip(input:{
+              userId: "#{attributes[:userId]}"
+              name: "#{attributes[:name]}"
+              traveledTo: #{attributes[:traveledTo]}
+              }) {
+                id
+                userId
+                name
+                traveledTo
+              }
+            }
+      GQL
+    end
+  end
+end


### PR DESCRIPTION
**What was changed**
- Add createTrip mutation (belongs to user)
- Remove boolean validation on traveled_to on Trips
  -  this was throwing an error when client sent request to create a new trip in which traveled_to was false because the validation thought it didn't exist (created separate ticket to look into boolean validation)

**Tracking**
- Closes #18

**Checklist:**
- [x] Added labels to PR
- [x] Addressed Rubocop violations
