### PR TITLE
Add unsplashid to photos

### DIFF
--- a/app/graphql/types/photo_type.rb
+++ b/app/graphql/types/photo_type.rb
@@ -4,5 +4,6 @@ module Types
     field :url, String, null: false
     field :artist_name, String, null: false
     field :artist_profile, String, null: false
+    field :unsplash_id, String, null: true
   end
 end

--- a/app/poros/photo_details.rb
+++ b/app/poros/photo_details.rb
@@ -2,12 +2,14 @@ class PhotoDetails
   attr_reader :description,
               :url,
               :artist_name,
-              :artist_profile
+              :artist_profile,
+              :unsplash_id
 
   def initialize(details)
     @description = details[:description]
     @url = details[:urls][:regular]
     @artist_name = details[:user][:name]
     @artist_profile = details[:user][:links][:html]
+    @unsplash_id = details[:id]
   end
 end

--- a/db/migrate/20210115021749_add_unsplash_id_to_photos.rb
+++ b/db/migrate/20210115021749_add_unsplash_id_to_photos.rb
@@ -1,0 +1,5 @@
+class AddUnsplashIdToPhotos < ActiveRecord::Migration[6.1]
+  def change
+    add_column :photos, :unsplash_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_14_033730) do
+ActiveRecord::Schema.define(version: 2021_01_15_021749) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2021_01_14_033730) do
     t.boolean "user_uploaded?"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "unsplash_id"
     t.index ["url"], name: "index_photos_on_url", unique: true
   end
 

--- a/spec/facades/photo_facade_spec.rb
+++ b/spec/facades/photo_facade_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Photo Facade' do
         expect(photo.url).to be_a(String)
         expect(photo.artist_name).to be_a(String)
         expect(photo.artist_profile).to be_a(String)
+        expect(photo.unsplash_id).to be_a(String)
       end
     end
   end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -7,6 +7,9 @@ module Helpers
     first_result = response[:results][0]
     expect(first_result).to be_a(Hash)
 
+    expect(first_result).to have_key(:id)
+    expect(first_result[:id]).to be_a(String)
+
     expect(first_result).to have_key(:description)
     expect(first_result[:description]).to be_a(String).or eq(nil)
 

--- a/spec/poros/photo_details_spec.rb
+++ b/spec/poros/photo_details_spec.rb
@@ -74,5 +74,6 @@ RSpec.describe 'Photo Details PORO' do
     expect(photo.url).to eq(symbolized_attr[:urls][:regular])
     expect(photo.artist_name).to eq(symbolized_attr[:user][:name])
     expect(photo.artist_profile).to eq(symbolized_attr[:user][:links][:html])
+    expect(photo.unsplash_id).to eq(symbolized_attr[:id])
   end
 end

--- a/spec/requests/graphql/queries/photos/search_photos_spec.rb
+++ b/spec/requests/graphql/queries/photos/search_photos_spec.rb
@@ -11,15 +11,19 @@ RSpec.describe Types::QueryType do
 
         result[:data][:searchPhotos].each do |result|
           expect(result).to have_key(:description)
-          expect(result[:description]).to be_a(String)
+          expect(result[:description]).to be_a(String).or eq(nil)
+
           expect(result).to have_key(:url)
           expect(result[:url]).to be_a(String)
+
           expect(result).to have_key(:artistName)
           expect(result[:artistName]).to be_a(String)
+
           expect(result).to have_key(:artistProfile)
           expect(result[:artistProfile]).to be_a(String)
-          expect(result).to have_key(:unsplashID)
-          expect(result[:unsplashID]).to be_a(String)
+
+          expect(result).to have_key(:unsplashId)
+          expect(result[:unsplashId]).to be_a(String)
         end
       end
     end
@@ -42,7 +46,7 @@ RSpec.describe Types::QueryType do
           url
           artistName
           artistProfile
-          unsplashID
+          unsplashId
         }
       }
     GQL

--- a/spec/requests/graphql/queries/photos/search_photos_spec.rb
+++ b/spec/requests/graphql/queries/photos/search_photos_spec.rb
@@ -11,9 +11,15 @@ RSpec.describe Types::QueryType do
 
         result[:data][:searchPhotos].each do |result|
           expect(result).to have_key(:description)
+          expect(result[:description]).to be_a(String)
           expect(result).to have_key(:url)
+          expect(result[:url]).to be_a(String)
           expect(result).to have_key(:artistName)
+          expect(result[:artistName]).to be_a(String)
           expect(result).to have_key(:artistProfile)
+          expect(result[:artistProfile]).to be_a(String)
+          expect(result).to have_key(:unsplashID)
+          expect(result[:unsplashID]).to be_a(String)
         end
       end
     end
@@ -36,6 +42,7 @@ RSpec.describe Types::QueryType do
           url
           artistName
           artistProfile
+          unsplashID
         }
       }
     GQL


### PR DESCRIPTION
**What was changed**
- Decided to store Unsplash's ID (string, ex: :id=>"rknrvCrfS1k"). This way in case the URL changes, I can still trace back to the original image if needed
- No model validations as not a required attribute
- Exposed in search_photos query and test
- Update photo_details poro and test
- Update service and facade tests

**Tracking**
- Closes #34

**Checklist:**
- [x] Added labels to PR
- [x] Addressed Rubocop violations
