### PR TITLE
Create add photo to trip mutation

### DIFF
--- a/app/graphql/mutations/photos/add_photo_to_trip.rb
+++ b/app/graphql/mutations/photos/add_photo_to_trip.rb
@@ -15,9 +15,6 @@ module Mutations
         photo = Photo.find_by(unsplash_id: attributes[:unsplash_id])
         PhotoTrip.create!(photo_id: photo.id, trip_id: attributes[:trip_id])
         photo
-        # add photo to db if it doesn't yet exist
-        # set user uploaded to false
-        # create new trip_photo
       end
     end
   end

--- a/app/graphql/mutations/photos/add_photo_to_trip.rb
+++ b/app/graphql/mutations/photos/add_photo_to_trip.rb
@@ -1,0 +1,24 @@
+module Mutations
+  module Photos
+    class AddPhotoToTrip < Mutations::BaseMutation
+      argument :trip_id, ID, required: true
+      argument :url, String, required: true
+      argument :artist_name, String, required: true
+      argument :artist_profile, String, required: true
+      argument :unsplash_id, String, required: true
+
+      type Types::PhotoType
+
+      def resolve(attributes)
+        attributes[:user_uploaded] = false
+        Photo.create!(attributes.except(:trip_id)) unless Photo.find_by(unsplash_id: attributes[:unsplash_id])
+        photo = Photo.find_by(unsplash_id: attributes[:unsplash_id])
+        PhotoTrip.create!(photo_id: photo.id, trip_id: attributes[:trip_id])
+        photo
+        # add photo to db if it doesn't yet exist
+        # set user uploaded to false
+        # create new trip_photo
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,5 +1,9 @@
 module Types
   class MutationType < Types::BaseObject
+    # Trips
     field :create_trip, mutation: Mutations::Trips::CreateTrip, description: 'Create a new trip'
+
+    # Photos
+    field :add_photo_to_trip, mutation: Mutations::Photos::AddPhotoToTrip, description: 'Add an Unsplash photo to a trip'
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -4,6 +4,7 @@ module Types
     field :create_trip, mutation: Mutations::Trips::CreateTrip, description: 'Create a new trip'
 
     # Photos
-    field :add_photo_to_trip, mutation: Mutations::Photos::AddPhotoToTrip, description: 'Add an Unsplash photo to a trip'
+    field :add_photo_to_trip, mutation: Mutations::Photos::AddPhotoToTrip,
+                              description: 'Add an Unsplash photo to a trip'
   end
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -3,5 +3,4 @@ class Photo < ApplicationRecord
   has_many :trips, through: :photo_trips
 
   validates :url, presence: true
-  validates :unsplash_id, uniqueness: true
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -2,6 +2,6 @@ class Photo < ApplicationRecord
   has_many :photo_trips, dependent: :destroy
   has_many :trips, through: :photo_trips
 
-  validates :url, presence: true, uniqueness: true
-  validates :user_uploaded?, presence: true
+  validates :url, presence: true
+  validates :unsplash_id, uniqueness: true
 end

--- a/db/migrate/20210114020203_create_photos.rb
+++ b/db/migrate/20210114020203_create_photos.rb
@@ -4,7 +4,7 @@ class CreatePhotos < ActiveRecord::Migration[6.1]
       t.string :url, index: { unique: true }
       t.string :artist_name
       t.string :artist_profile
-      t.boolean :user_uploaded?
+      t.boolean :user_uploaded, null: false
 
       t.timestamps
     end

--- a/db/migrate/20210115021749_add_unsplash_id_to_photos.rb
+++ b/db/migrate/20210115021749_add_unsplash_id_to_photos.rb
@@ -1,5 +1,5 @@
 class AddUnsplashIdToPhotos < ActiveRecord::Migration[6.1]
   def change
-    add_column :photos, :unsplash_id, :string
+    add_column :photos, :unsplash_id, :string, null: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2021_01_15_021749) do
     t.string "url"
     t.string "artist_name"
     t.string "artist_profile"
-    t.boolean "user_uploaded?"
+    t.boolean "user_uploaded", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "unsplash_id"

--- a/spec/factories/photo.rb
+++ b/spec/factories/photo.rb
@@ -1,7 +1,0 @@
-FactoryBot.define do
-  factory :photo do
-    description { Faker::Hipster.sentence }
-    url { Faker::Avatar.image }
-    artist {{ name: Faker::Artist.name, profile: Faker::Internet.url }} 
-  end
-end

--- a/spec/factories/trip.rb
+++ b/spec/factories/trip.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :trip do
+    name { Faker::JapaneseMedia::StudioGhibli.character }
+    traveled_to { [true, false].sample }
+    association :user
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,5 +2,11 @@ FactoryBot.define do
   factory :user do
     email { Faker::Internet.unique.email }
     password_digest { Faker::Internet.password }
+
+    trait :with_trips do
+      after(:create) do |user|
+        create_list(:trip, 3, user: user)
+      end
+    end
   end
 end

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -8,6 +8,5 @@ RSpec.describe Photo, type: :model do
   
   describe 'validations' do
     it { should validate_presence_of :url }
-    it { should validate_uniqueness_of :unsplash_id }
   end
 end

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Photo, type: :model do
   
   describe 'validations' do
     it { should validate_presence_of :url }
-    it { should validate_uniqueness_of :url }
-    it { should validate_presence_of :user_uploaded? }
+    it { should validate_uniqueness_of :unsplash_id }
   end
 end

--- a/spec/requests/graphql/mutations/photos/add_photo_to_trip_spec.rb
+++ b/spec/requests/graphql/mutations/photos/add_photo_to_trip_spec.rb
@@ -4,39 +4,95 @@ RSpec.describe Mutations::Photos::AddPhotoToTrip, type: :request do
   describe '.resolve' do
     before :each do
       @user = create(:user, :with_trips)
-    end   
 
-    it 'adds an Unsplash photo to a trip' do
-      attributes = {
+      @attributes = {
         tripId: @user.trips.first.id,
         url: 'https://images.unsplash.com/photo-1516483638261-f4dbaf036963?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MXwxODEwNDd8MHwxfHNlYXJjaHwxfHxJdGFseXxlbnwwfHx8&ixlib=rb-1.2.1&q=80&w=1080',
         artistName: 'Jack Ward',
         artistProfile: 'https://unsplash.com/@jackward',
         unsplashId: 'rknrvCrfS1k'
       }
+    end   
 
-      post graphql_path, params: { query: query(attributes) }
-      result = JSON.parse(response.body)
+    it 'creates an Unsplash photo and adds to a trip' do
+      post graphql_path, params: { query: query(@attributes) }
+      result = JSON.parse(response.body, symbolize_names: true)
 
       expect(Photo.count).to eq(1)
-      data = result['data']['addPhotoToTrip']
-      expect(data['url']).to eq(attributes[:url])
-      expect(data['artistName']).to eq(attributes[:artistName])
-      expect(data['artistProfile']).to eq(attributes[:artistProfile])
-      expect(data['unsplashId']).to eq(attributes[:unsplashId])
+      expect(PhotoTrip.count).to eq(1)
+      expect(PhotoTrip.first.photo_id).to eq(Photo.first.id)
+      expect(PhotoTrip.first.trip_id).to eq(@user.trips.first.id)
+
+      data = result[:data][:addPhotoToTrip]
+      expect(data[:url]).to eq(@attributes[:url])
+      expect(data[:artistName]).to eq(@attributes[:artistName])
+      expect(data[:artistProfile]).to eq(@attributes[:artistProfile])
+      expect(data[:unsplashId]).to eq(@attributes[:unsplashId])
     end
 
-    # add sad path for not passing in unsplash attrs 
+    it 'does not create an Unsplash photo without attribution' do
+      post '/graphql', params: { query:
+        <<~GQL
+        mutation {
+          addPhotoToTrip(input: {
+            tripId: #{@user.trips.first.id}
+            url: "#{@attributes[:url]}"
+            unsplashId: "#{@attributes[:unsplashId]}"
+            }) {
+              url
+              artistName
+              artistProfile
+              unsplashId
+            }
+          }
+        GQL
+      }
+
+      expect(Photo.count).to eq(0)
+      expect(PhotoTrip.count).to eq(0)
+
+      result = JSON.parse(response.body, symbolize_names: true)
+
+      expect(result[:errors][0][:message]).to eq("Argument 'artistName' on InputObject 'AddPhotoToTripInput' is required. Expected type String!")
+      expect(result[:errors][1][:message]).to eq("Argument 'artistProfile' on InputObject 'AddPhotoToTripInput' is required. Expected type String!")
+    end
+
+    it 'does not create an Unsplash photo without an Unsplash ID' do
+      post '/graphql', params: { query:
+        <<~GQL
+        mutation {
+          addPhotoToTrip(input: {
+            tripId: #{@user.trips.first.id}
+            url: "#{@attributes[:url]}"
+            artistName: "#{@attributes[:artistName]}"
+            artistProfile: "#{@attributes[:artistProfile]}"
+            }) {
+              url
+              artistName
+              artistProfile
+              unsplashId
+            }
+          }
+        GQL
+      }
+
+      expect(Photo.count).to eq(0)
+      expect(PhotoTrip.count).to eq(0)
+
+      result = JSON.parse(response.body, symbolize_names: true)
+    
+      expect(result[:errors][0][:message]).to eq("Argument 'unsplashId' on InputObject 'AddPhotoToTripInput' is required. Expected type String!")
+    end
 
     def query(attributes)
       <<~GQL
         mutation {
           addPhotoToTrip(input:{
-              tripId: "#{attributes[:tripId]}"
-              url: "#{attributes[:url]}"
-              artistName: "#{attributes[:artistName]}"
-              artistProfile: "#{attributes[:artistProfile]}"
-              unsplashId: "#{attributes[:unsplashId]}"
+              tripId: "#{@attributes[:tripId]}"
+              url: "#{@attributes[:url]}"
+              artistName: "#{@attributes[:artistName]}"
+              artistProfile: "#{@attributes[:artistProfile]}"
+              unsplashId: "#{@attributes[:unsplashId]}"
               }) {
                 url
                 artistName

--- a/spec/requests/graphql/mutations/photos/add_photo_to_trip_spec.rb
+++ b/spec/requests/graphql/mutations/photos/add_photo_to_trip_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Mutations::Photos::AddPhotoToTrip, type: :request do
+  describe '.resolve' do
+    before :each do
+      @user = create(:user, :with_trips)
+    end   
+
+    it 'adds an Unsplash photo to a trip' do
+      attributes = {
+        tripId: @user.trips.first.id,
+        url: 'https://images.unsplash.com/photo-1516483638261-f4dbaf036963?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MXwxODEwNDd8MHwxfHNlYXJjaHwxfHxJdGFseXxlbnwwfHx8&ixlib=rb-1.2.1&q=80&w=1080',
+        artistName: 'Jack Ward',
+        artistProfile: 'https://unsplash.com/@jackward',
+        unsplashId: 'rknrvCrfS1k'
+      }
+
+      post graphql_path, params: { query: query(attributes) }
+      result = JSON.parse(response.body)
+
+      expect(Photo.count).to eq(1)
+      data = result['data']['addPhotoToTrip']
+      expect(data['url']).to eq(attributes[:url])
+      expect(data['artistName']).to eq(attributes[:artistName])
+      expect(data['artistProfile']).to eq(attributes[:artistProfile])
+      expect(data['unsplashId']).to eq(attributes[:unsplashId])
+    end
+
+    # add sad path for not passing in unsplash attrs 
+
+    def query(attributes)
+      <<~GQL
+        mutation {
+          addPhotoToTrip(input:{
+              tripId: "#{attributes[:tripId]}"
+              url: "#{attributes[:url]}"
+              artistName: "#{attributes[:artistName]}"
+              artistProfile: "#{attributes[:artistProfile]}"
+              unsplashId: "#{attributes[:unsplashId]}"
+              }) {
+                url
+                artistName
+                artistProfile
+                unsplashId
+              }
+            }
+      GQL
+    end
+  end
+end


### PR DESCRIPTION
**What was changed**
- Save Unsplash photo to database when users adds to a trip 
- This action also creates a photo_trip record
- Artist attribution is required when saving a photo to db

**Tracking**
- Closes #15 

**Checklist:**
- [x] Added labels to PR
- [x] Addressed Rubocop violations
