### PR TITLE
Add get_user query and add photo and trip to user type

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -12,14 +12,23 @@ module Types
     # Users
     field :get_users, [Types::UserType], null: false, description: 'Returns a list of all users'
 
+    field :get_user, Types::UserType, null: false, description: 'Returns a user by user id' do
+      argument :id, ID, required: true
+    end
+
     def get_users
       User.all
+    end
+
+    def get_user(id:)
+      User.find(id)
     end
 
     # Trips
     field :get_trip, Types::TripType, null: false, description: 'Returns a trip by trip id' do
       argument :id, ID, required: true
     end
+
     field :top_destinations, [Types::DestinationType], null: false,
                                                        description: 'Returns top destinations (most saved trips)' do
       argument :limit, Integer, required: false

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -2,5 +2,7 @@ module Types
   class UserType < Types::BaseObject
     field :id, ID, null: false
     field :email, String, null: false
+    field :photos, [Types::PhotoType], null: false
+    field :trips, [Types::TripType], null: false
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   has_secure_password
   has_many :trips, dependent: :destroy
+  has_many :photo_trips, through: :trips
+  has_many :photos, through: :photo_trips
 
   validates :email, uniqueness: true, presence: true
   validates :password_digest, presence: true

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -8,5 +8,14 @@ FactoryBot.define do
         create_list(:trip, 3, user: user)
       end
     end
+
+    trait :with_photo_trip do
+      after(:create) do |user|
+        trips = create_list(:trip, 2, user: user)
+        trips[0].photos << create(:photo, user_uploaded: true)
+        trips[0].photos << create(:photo, user_uploaded: false)
+        trips[1].photos << create(:photo, user_uploaded: true)
+      end
+    end
   end
 end

--- a/spec/requests/graphql/queries/users/get_single_user_spec.rb
+++ b/spec/requests/graphql/queries/users/get_single_user_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe Types::QueryType do
+  describe 'fetch single user' do
+    it 'can query single user by ID' do
+      user = create(:user, :with_photo_trip)
+
+      post graphql_path, params: { query: query(id: user.id) }
+      result = JSON.parse(response.body, symbolize_names: true)
+
+      data = result[:data][:getUser]
+
+      expect(data[:id]).to eq(user.id.to_s)
+      expect(data[:email]).to eq(user.email.to_s)
+      
+      expect(data[:photos]).to match_array(user.photos.map do |photo|
+        {
+          id: photo.id.to_s,
+          url: photo.url,
+          artistName: photo.artist_name,
+          artistProfile: photo.artist_profile,
+          unsplashId: photo.unsplash_id,
+          userUploaded: photo.user_uploaded 
+        }
+      end
+      )
+
+      expect(data[:trips]).to match_array(user.trips.map do |trip|
+        {
+          id: trip.id.to_s,
+          userId: user.id.to_s,
+          destination: trip.destination,
+          traveledTo: trip.traveled_to,
+          latitude: trip.latitude,
+          longitude: trip.longitude,
+          photos: trip.photos.map do |photo|
+            {
+              id: photo.id.to_s,
+              url: photo.url,
+              artistName: photo.artist_name,
+              artistProfile: photo.artist_profile,
+              unsplashId: photo.unsplash_id,
+              userUploaded: photo.user_uploaded 
+            }
+          end
+        }
+      end
+      )
+    end
+  end
+
+  def query(id:)
+    <<~GQL
+      {
+        getUser(id: "#{id}") {
+          id
+          email
+          photos {
+            id
+            url
+            artistName
+            artistProfile
+            unsplashId
+            userUploaded
+          }
+          trips {
+            id
+            userId
+            destination
+            traveledTo
+            latitude
+            longitude
+            photos {
+              id
+              url
+              artistName
+              artistProfile
+              unsplashId
+              userUploaded
+            }
+          }
+        }
+      }
+    GQL
+  end
+end

--- a/spec/requests/graphql/queries/users/get_users_spec.rb
+++ b/spec/requests/graphql/queries/users/get_users_spec.rb
@@ -1,20 +1,54 @@
 require 'rails_helper'
 
 RSpec.describe Types::QueryType do
-  describe 'display users' do
+  describe 'fetch all users' do
     it 'can query all users' do
-      create_list(:user, 2)
+      create_list(:user, 2, :with_photo_trip)
 
       post graphql_path, params: { query: query }
-      result = JSON.parse(response.body)
+      result = JSON.parse(response.body, symbolize_names: true)
+      data = result[:data][:getUsers]
 
-      expect(result['data']['getUsers'].count).to eq(2)
+      expect(data.size).to eq(2)
 
       users = User.all
 
-      expect(result.dig('data', 'getUsers')).to match_array(
+      expect(data).to match_array(
         users.map do |user|
-          { 'id' => user.id.to_s, 'email' => user.email }
+          { 
+            id: user.id.to_s, 
+            email: user.email,
+            photos: user.photos.map do |photo|
+              {
+                id: photo.id.to_s,
+                url: photo.url,
+                artistName: photo.artist_name,
+                artistProfile: photo.artist_profile,
+                unsplashId: photo.unsplash_id,
+                userUploaded: photo.user_uploaded 
+              }
+            end,
+            trips: user.trips.map do |trip|
+              {
+                id: trip.id.to_s,
+                userId: user.id.to_s,
+                destination: trip.destination,
+                traveledTo: trip.traveled_to,
+                latitude: trip.latitude,
+                longitude: trip.longitude,
+                photos: trip.photos.map do |photo|
+                  {
+                    id: photo.id.to_s,
+                    url: photo.url,
+                    artistName: photo.artist_name,
+                    artistProfile: photo.artist_profile,
+                    unsplashId: photo.unsplash_id,
+                    userUploaded: photo.user_uploaded 
+                  }
+                end
+              }
+            end
+          }
         end
       )
     end
@@ -26,6 +60,30 @@ RSpec.describe Types::QueryType do
         getUsers {
           id
           email
+          photos {
+            id
+            url
+            artistName
+            artistProfile
+            unsplashId
+            userUploaded
+          }
+          trips {
+            id
+            userId
+            destination
+            traveledTo
+            latitude
+            longitude
+            photos {
+              id
+              url
+              artistName
+              artistProfile
+              unsplashId
+              userUploaded
+            }
+          }
         }
       }
     GQL


### PR DESCRIPTION
**What was changed**
- Add association of photos and photo_trips to user model 
- Adds photo type and trip type to user type
- Update get_users spec to reflect users' photos and trips in response
- Create get_user query for single user by ID and add spec

**Tracking**
- Closes #20
- Closes #60

**Checklist:**
- [x] Added labels to PR
- [x] Addressed Rubocop violations
