### PR TITLE
Rename repo to virtual_escape_api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ deploy:
   provider: heroku
   api_key:
     secure: jRVHIdbzhlwdJnuyb4pshhZXPxPMdVqxJLsWSek56jkwvg39TXBhNDvYLdxY6Yex4MoVZtYIE1REqXMffh5oNCvb9EnocKUBFBKY+b0YAtwfBOuYWj0qbddEIsxEiPNwQDgZSTB9Q/8i4tHPpDJ/9JjCFZc7+eYA6KLi+MW2sr8grzlEO2d2vlPm35CsHVU8osAfnp85AMozMgYIACr+lqn/uSsj6uobLLYTI5aZO8zonApqK7Cbxko/GLqhZCcpZN2C7ADT+n7U0A6nOIdKcJu/zaF2tEkD0o3m+6y97mYk4AiUqI/pcNZ6h1dHk1VhxNvY9/F8h/OB8S11nOVNRcbZevolT2Xm9nY+JD6S1aTjVUazObcOMHnGUziMH1hJeuF7vRlRvgS4owSaMpuuA4aTsiPUWAaBryJ9FB2rWLqoGmFWCwEVYobmKftUBhIGYxOEc2xCtfHKzVtfRwNvlCkxy3P4MCoTIloudnWm2QA5QM54Ut4gHO+gUvrOvn6xTeOK/9qmKpz5mX8sRfg4qKjW/FIxz112TidtWz5WjhZ5J9SeJDzd6SKVep7aBqPQbjMSzL474D8vT5Ab75e6mv3sW5o56SVPr736b37L4d07uBEADyVS6FRm8xFEt64SlPtc0/k9TEI86dHzepMvV/nIEmndtQR8J7gq8z5VQmI=
-  app: photo-repo-api
+  app: virtual-escape-api
   on:
-    repo: photo_repo_api
+    repo: virtual_escape_api
     branch: main
   skip_cleanup: 'true'
 notifications:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <img src="app/assets/images/logo.png" alt="logo" max-width="600"><br>
 
-![rails-badge](https://img.shields.io/badge/Rails-6.1.0-informational?style=flat-square) ![ruby-badge](https://img.shields.io/badge/Ruby-2.5.3-informational?style=flat-square) ![build-badge](https://img.shields.io/travis/leahriffell/photo_repo_api/main?style=flat-square) ![closed-pr-badge](https://img.shields.io/github/issues-pr-closed-raw/leahriffell/photo_repo_api?style=flat-square)
+![rails-badge](https://img.shields.io/badge/Rails-6.1.0-informational?style=flat-square) ![ruby-badge](https://img.shields.io/badge/Ruby-2.5.3-informational?style=flat-square) ![build-badge](https://img.shields.io/travis/com/leahriffell/virtual_escape_api/main?style=flat-square) ![closed-pr-badge](https://img.shields.io/github/issues-pr-closed-raw/leahriffell/virtual_escape_api?style=flat-square)
 
-This GraphQL on Rails API ([deployed endpoint](https://photo-repo-api.herokuapp.com/graphql)) serves queries and mutations for Virtual Escape, an application that allows you to travel in covid-safe style from your couch (or, let's be real, bed). There's a whole world out there so put on your best sweats and come TFH (travel from home)!
+This GraphQL on Rails API ([deployed endpoint](https://virtual-escape-api.herokuapp.com/graphql)) serves queries and mutations for Virtual Escape, an application that allows you to travel in covid-safe style from your couch (or, let's be real, bed). There's a whole world out there so put on your best sweats and come TFH (travel from home)!
 
 #### What can I do on Virtual Escape?
   - Search for a destination and see matching photos
@@ -74,7 +74,7 @@ This API consumes the following APIs:
 - 97% test coverage
 
 # GraphQL Schema
-Endpoint (direct your POST requests here): https://photo-repo-api.herokuapp.com/graphql
+Endpoint (direct your POST requests here): https://virtual-escape-api.herokuapp.com/graphql
 
 ### Resource Queries
 #### Photos
@@ -192,14 +192,14 @@ Endpoint (direct your POST requests here): https://photo-repo-api.herokuapp.com/
 <img src="app/assets/images/schema.png" alt="database-schema" max-width="800"><br>
 
 # Project Tracking
-**[GitHub project](https://github.com/leahriffell/photo_repo_api/projects/1)**
+**[GitHub project](https://github.com/leahriffell/virtual_escape_api/projects/1)**
   - I used branching and pull requests to maintain clean version control
 
 Next top priorities:
-  - User authentication with Firebase or Auth0 ([#16](https://github.com/leahriffell/photo_repo_api/issues/16))
-  - Research and implement testing of file uploading to avoid having to locally test in Altair ([#66](https://github.com/leahriffell/photo_repo_api/issues/66))
-  - Add edit and delete photo functionality ([#22](https://github.com/leahriffell/photo_repo_api/issues/22), [#40](https://github.com/leahriffell/photo_repo_api/issues/40))
-  - More insight queries like most saved photo, trending destinations, etc. ([#55](https://github.com/leahriffell/photo_repo_api/issues/55), [#53](https://github.com/leahriffell/photo_repo_api/issues/53), [#54](https://github.com/leahriffell/photo_repo_api/issues/54))
+  - User authentication with Firebase or Auth0 ([#16](https://github.com/leahriffell/virtual_escape_api/issues/16))
+  - Research and implement testing of file uploading to avoid having to locally test in Altair ([#66](https://github.com/leahriffell/virtual_escape_api/issues/66))
+  - Add edit and delete photo functionality ([#22](https://github.com/leahriffell/virtual_escape_api/issues/22), [#40](https://github.com/leahriffell/virtual_escape_api/issues/40))
+  - More insight queries like most saved photo, trending destinations, etc. ([#55](https://github.com/leahriffell/virtual_escape_api/issues/55), [#53](https://github.com/leahriffell/virtual_escape_api/issues/53), [#54](https://github.com/leahriffell/virtual_escape_api/issues/54))
 
 
 # Contributor

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,4 +7,4 @@ test:
 production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: photo_repo_api_production
+  channel_prefix: virtual_escape_api_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,13 +23,13 @@ default: &default
 
 development:
   <<: *default
-  database: photo_repo_api_development
+  database: virtual_escape_api_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user running Rails.
-  #username: photo_repo_api
+  #username: virtual_escape_api
 
   # The password associated with the postgres role (username).
   #password:
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: photo_repo_api_test
+  database: virtual_escape_api_test
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -81,6 +81,6 @@ test:
 #
 production:
   <<: *default
-  database: photo_repo_api_production
-  username: photo_repo_api
-  password: <%= ENV['PHOTO_REPO_API_DATABASE_PASSWORD'] %>
+  database: virtual_escape_api_production
+  username: virtual_escape_api
+  password: <%= ENV['VIRTUAL_ESCAPE_API_DATABASE_PASSWORD'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "photo_repo_api_production"
+  # config.active_job.queue_name_prefix = "virtual_escape_api_production"
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
**What was changed**
- Rename repo and heroku app to match Virtual Escape (previously just generic photo_repo) for consistency

**Checklist:**
- [x] Added labels to PR
- [x] Addressed Rubocop violations
